### PR TITLE
Fix for uri conversion

### DIFF
--- a/lib/uri-beacon-scanner.js
+++ b/lib/uri-beacon-scanner.js
@@ -63,29 +63,25 @@ UriBeaconScanner.prototype.parseUriBeacon = function(peripheral) {
 
   var flags = data.readUInt8(0); // flag is the 1st byte
   var txPower = data.readInt8(1); // TX Power is 2nd byte
-  var uriData = data.slice(2); // remainder in the URI
-
+  var firstByte = data[2];
+  var uriData = data.slice(3); // remainder in the URI
   var uriPrefix = '';
-  var uriSuffix = '';
-
-  var firstByte = data[0];
-  var lastByte = data[data.length - 1];
 
   // decode prefix, if needed
   if (firstByte < PREFIXES.length) {
     uriPrefix = PREFIXES[firstByte];
-    data = data.slice(1);
   }
 
-  // decode suffic, if needed
-  if (lastByte < SUFFIXES.length) {
-    uriSuffix = SUFFIXES[lastByte];
-    data = data.slice(0, data.length - 1);
+  var uri = uriPrefix;
+  for (x = 0; x < uriData.length; x++) {
+    debug('Convert uri: %s', String.fromCharCode(uriData[x]));
+    if (uriData[x] < SUFFIXES.length) {
+      uri += SUFFIXES[uriData[x]];
+    } else {
+      uri += String.fromCharCode(uriData[x]);
+    }
+
   }
-
-  // assemble URI
-  var uri = uriPrefix + uriData.toString() + uriSuffix;
-
   return {
     flags: flags,
     txPower: txPower,

--- a/lib/uri-beacon-scanner.js
+++ b/lib/uri-beacon-scanner.js
@@ -63,16 +63,17 @@ UriBeaconScanner.prototype.parseUriBeacon = function(peripheral) {
 
   var flags = data.readUInt8(0); // flag is the 1st byte
   var txPower = data.readInt8(1); // TX Power is 2nd byte
-  var firstByte = data[2];
+  var uriScheme = data[2];
   var uriData = data.slice(3); // remainder in the URI
-  var uriPrefix = '';
+  var uri = '';
 
   // decode prefix, if needed
-  if (firstByte < PREFIXES.length) {
-    uriPrefix = PREFIXES[firstByte];
+  if (uriScheme < PREFIXES.length) {
+    uri = PREFIXES[uriScheme];
+  } else {
+    uri = String.fromCharCode(uriScheme);
   }
 
-  var uri = uriPrefix;
   for (x = 0; x < uriData.length; x++) {
     debug('Convert uri: %s', String.fromCharCode(uriData[x]));
     if (uriData[x] < SUFFIXES.length) {


### PR DESCRIPTION
There were a couple of uri's that the code was having a problem with. These were http://goo.gl/nps6ze
and http://www.csr.com/about.
It appears the code wasn't handling uri's correctly if it did not start with http:www. and it assumed the UriBeacon HTTP URL encoding was a suffix which may not be the case according to my understanding of the spec and the [uri packet generator](https://learn.adafruit.com/google-physical-web-uribeacon-with-the-bluefruit-le-friend/getting-started#uribeacon-packet-generator).