### PR TITLE
Make the grace period configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ The ```beacon``` object will have the following properties depending on the fram
 
 Start scanning for Eddystone beacons, you can specify whether to allow duplicates (default is false).
 
+You can also specify the grace period (time to wait before declaring the beacon as lost). Default is 5000 ms.
+
 ```javascript
-EddystoneBeaconScanner.startScanning(allowDuplicates);
+EddystoneBeaconScanner.startScanning(allowDuplicates, gracePeriod);
 ```
 
 __Note:__ the ```lost``` event will only be triggered when ```allowDuplicates``` is set to true.

--- a/lib/eddystone-beacon-scanner.js
+++ b/lib/eddystone-beacon-scanner.js
@@ -38,13 +38,10 @@ EddystoneBeaconScanner.prototype.startScanning = function(allowDuplicates, grace
 
   startScanningOnPowerOn();
 
-  if (gracePeriod) {
-    EXIT_GRACE_PERIOD = gracePeriod;
-  }
-
+  this._gracePeriod = (gracePeriod === undefined) ? EXIT_GRACE_PERIOD : gracePeriod;
   this._allowDuplicates = allowDuplicates;
   if (allowDuplicates) {
-    this._lostCheckInterval = setInterval(this.checkLost.bind(this), EXIT_GRACE_PERIOD / 2);
+    this._lostCheckInterval = setInterval(this.checkLost.bind(this), this._gracePeriod / 2);
   }
 };
 
@@ -92,7 +89,7 @@ EddystoneBeaconScanner.prototype.checkLost = function() {
   for (var id in this._discovered) {
     var beacon = this._discovered[id];
 
-    if (this._discovered[id].lastSeen < (Date.now() - EXIT_GRACE_PERIOD)) {
+    if (this._discovered[id].lastSeen < (Date.now() - this._gracePeriod)) {
       this.emit('lost', beacon);
 
       delete this._discovered[id];

--- a/lib/eddystone-beacon-scanner.js
+++ b/lib/eddystone-beacon-scanner.js
@@ -25,7 +25,7 @@ var EddystoneBeaconScanner = function() {
 
 util.inherits(EddystoneBeaconScanner, events.EventEmitter);
 
-EddystoneBeaconScanner.prototype.startScanning = function(allowDuplicates) {
+EddystoneBeaconScanner.prototype.startScanning = function(allowDuplicates, gracePeriod) {
   debug('startScanning');
 
   var startScanningOnPowerOn = function() {
@@ -37,6 +37,10 @@ EddystoneBeaconScanner.prototype.startScanning = function(allowDuplicates) {
   };
 
   startScanningOnPowerOn();
+
+  if (gracePeriod) {
+    EXIT_GRACE_PERIOD = gracePeriod;
+  }
 
   this._allowDuplicates = allowDuplicates;
   if (allowDuplicates) {


### PR DESCRIPTION
A simple PR to make the grace period configurable:

```js
EddystoneBeaconScanner.startScanning(true, 30000); // Increase the grace period to 30s
```

The default value is still of 5 seconds.